### PR TITLE
Fixes #218 for now.

### DIFF
--- a/src/django/VLE/models.py
+++ b/src/django/VLE/models.py
@@ -12,7 +12,7 @@ from VLE.utils.file_handling import get_path
 class UserFile(models.Model):
     """UserFile.
 
-    UserFile is a file uploaded by the user stored in MEDIA_ROOT/files/uID/aID/...
+    UserFile is a file uploaded by the user stored in MEDIA_ROOT/uID/aID/...
     - author: The user who uploaded the file.
     - file_name: The name of the file (no parts of the path to the file included).
     - creation_date: The time and date the file was uploaded.

--- a/src/django/VLE/utils/file_handling.py
+++ b/src/django/VLE/utils/file_handling.py
@@ -1,8 +1,37 @@
 """
 File handling related utilites.
 """
+import shutil
+import json
+import os
+from django.conf import settings
 
 
 def get_path(instance, filename):
-    """Upload user files into their respective directories. Following MEDIA_ROOT/files/uID/aID/..."""
-    return 'files/' + str(instance.author.id) + '/' + str(instance.assignment.id) + '/' + filename
+    """Upload user files into their respective directories. Following MEDIA_ROOT/uID/aID/..."""
+    return str(instance.author.id) + '/' + str(instance.assignment.id) + '/' + filename
+
+
+def compress_all_user_data(user, extra_data_dict=None, archive_extension='zip'):
+    """Compresses all user files found in MEDIA_ROOT/uid into a single archiveself.
+
+    If an extra data dictionary is provided, this is json dumped and included in the archive as
+    information.json.
+    The archive is stored in MEDIA_ROOT/{username}_data_archive.{archive_extension}.
+    Please note that this archive is overwritten if it already exists."""
+    user_file_dir_path = os.path.join(settings.MEDIA_ROOT, str(user.id))
+    archive_name = user.username + '_data_archive'
+    archive_ouput_base_name = os.path.join(settings.MEDIA_ROOT, archive_name)
+    archive_ouput_path = archive_ouput_base_name + '.' + archive_extension
+    content_type = 'application/' + archive_extension
+
+    if extra_data_dict:
+        extra_data_dump_name = 'information.json'
+        extra_data_dump_path = os.path.join(user_file_dir_path, extra_data_dump_name)
+
+        with open(extra_data_dump_path, 'w') as file:
+            file.write(json.dumps(extra_data_dict))
+
+    shutil.make_archive(archive_ouput_base_name, archive_extension, user_file_dir_path)
+
+    return archive_ouput_path, content_type

--- a/src/django/VLE/views/get.py
+++ b/src/django/VLE/views/get.py
@@ -16,6 +16,7 @@ import jwt
 import VLE.lti_launch as lti
 import VLE.edag as edag
 import VLE.utils.generic_utils as utils
+import VLE.utils.file_handling as file_handling
 from VLE.models import Assignment, Course, Journal, EntryTemplate, EntryComment, User, Node, \
     Role, Entry, UserFile
 import VLE.serializers as serialize
@@ -746,7 +747,8 @@ def get_entrycomments(request, eID):
 def get_user_data(request, uID):
     """Get the user data of the given user.
 
-    Get his/her profile data and posted entries with the titles of the journals of the user based on the uID.
+    Get his/her profile data and posted entries with the titles of the journals of the user based on the uID. As well
+    as all the user uploaded files.
     """
     if not request.user.is_authenticated:
         return responses.unauthorized()
@@ -771,7 +773,10 @@ def get_user_data(request, uID):
         entries_of_journal = [serialize.export_entry_to_dict(node.entry) for node in nodes_of_journal_with_entries]
         journal_dict.update({journal.assignment.name: entries_of_journal})
 
-    return responses.success(payload={'profile': profile, 'journals': journal_dict})
+    archive_path, content_type = file_handling.compress_all_user_data(user,
+                                                                      {'profile': profile, 'journals': journal_dict})
+
+    return responses.file_b64(archive_path, content_type)
 
 
 @api_view(['GET'])
@@ -927,6 +932,6 @@ def get_user_file(request, file_name, author_uID):
 
     if user_file.author.id is user.id or \
        permissions.has_assignment_permission(user, user_file.assignment, 'can_view_assignment_participants'):
-        return responses.fileb64(user_file)
+        return responses.user_file_b64(user_file)
     else:
         return responses.unauthorized('Unauthorized to view: %s by author ID: %s.' % (file_name, author_uID))

--- a/src/django/VLE/views/get.py
+++ b/src/django/VLE/views/get.py
@@ -747,7 +747,7 @@ def get_entrycomments(request, eID):
 def get_user_data(request, uID):
     """Get the user data of the given user.
 
-    Get his/her profile data and posted entries with the titles of the journals of the user based on the uID. As well
+    Get the users profile data and posted entries with the titles of the journals of the user based on the uID. As well
     as all the user uploaded files.
     """
     if not request.user.is_authenticated:

--- a/src/django/VLE/views/responses.py
+++ b/src/django/VLE/views/responses.py
@@ -136,7 +136,7 @@ def keyerror(*keys):
         return bad_request(description='Fields {0} are required but one or more are missing.'.format(keys))
 
 
-def fileb64(user_file):
+def user_file_b64(user_file):
     """Return a file as base64 encoded binary string if found, otherwise returns a not found response."""
     file_path = os.path.join(MEDIA_ROOT, user_file.file.name)
     if os.path.exists(file_path):
@@ -150,9 +150,21 @@ def fileb64(user_file):
         return not_found(description='File not found.')
 
 
-def file(user_file):
-    """Return a file as blob if found, otherwise returns a not found response."""
-    file_path = os.path.join(MEDIA_ROOT, user_file.file.name)
+def file_b64(file_path, content_type):
+    """Return a file as base64 encoded binary string if found, otherwise returns a not found response."""
+    if os.path.exists(file_path):
+        with open(file_path, 'rb') as fp:
+            response = HttpResponse(base64.b64encode(fp.read()), content_type=content_type)
+            response['Content-Disposition'] = 'attachment; filename=' + os.path.basename(file_path)
+            # Exposes headers to the response in javascript lowercase recommended
+            response['access-control-expose-headers'] = 'content-disposition, content-type'
+            return response
+    else:
+        return not_found(description='File not found.')
+
+
+def file(file_path):
+    """Return a file as bytestring if found, otherwise returns a not found response."""
     try:
         response = FileResponse(open(file_path, 'rb'), as_attachment=True)
         return response

--- a/src/vue/src/api/user.js
+++ b/src/vue/src/api/user.js
@@ -11,7 +11,6 @@ export default {
      */
     getUserData (uID) {
         return auth.authenticatedGet('/get_user_data/' + uID + '/')
-            .then(response => response.data)
     },
 
     /* Get user file. */


### PR DESCRIPTION
## Description
A user can now download all of their respective user data, including files in one neat archive.

## Summary of changes
- Download of user data archive
- File structure changed to MEDIA_ROOT/uid/... instead of MEDIA_ROOT/files/uid/... This because the file directory was not needed, for the MEDIA_ROOT contains user files only.

![image](https://user-images.githubusercontent.com/39912610/44522370-96eb1100-a6d6-11e8-9d36-83f07279ca1e.png)

