### PR TITLE
Prevent deadlines after due date

### DIFF
--- a/src/vue/src/components/journal/JournalStudent.vue
+++ b/src/vue/src/components/journal/JournalStudent.vue
@@ -241,15 +241,7 @@ export default {
             var currentDate = new Date()
             var deadline = new Date(this.nodes[this.currentNode].deadline)
 
-<<<<<<< current
             return currentDate <= deadline
-=======
-            console.log(currentDate)
-            console.log(deadline)
-            console.log(new Date(this.assignment.due_date))
-
-            return currentDate <= deadline && currentDate <= new Date(this.assignment.due_date)
->>>>>>> before discard
         }
     },
     components: {

--- a/src/vue/src/components/journal/JournalStudent.vue
+++ b/src/vue/src/components/journal/JournalStudent.vue
@@ -241,7 +241,15 @@ export default {
             var currentDate = new Date()
             var deadline = new Date(this.nodes[this.currentNode].deadline)
 
+<<<<<<< current
             return currentDate <= deadline
+=======
+            console.log(currentDate)
+            console.log(deadline)
+            console.log(new Date(this.assignment.due_date))
+
+            return currentDate <= deadline && currentDate <= new Date(this.assignment.due_date)
+>>>>>>> before discard
         }
     },
     components: {

--- a/src/vue/src/components/journal/JournalStudent.vue
+++ b/src/vue/src/components/journal/JournalStudent.vue
@@ -241,7 +241,7 @@ export default {
             var currentDate = new Date()
             var deadline = new Date(this.nodes[this.currentNode].deadline)
 
-            return currentDate <= deadline && currentDate <= new Date(this.assignment.due_date)
+            return currentDate <= deadline
         }
     },
     components: {

--- a/src/vue/src/views/FormatEdit.vue
+++ b/src/vue/src/views/FormatEdit.vue
@@ -237,6 +237,7 @@ export default {
             var missingAssignmentName = false
             var missingPointMax = false
 
+            var deadlineAfterDueDate = false
             var invalidDate = false
             var invalidTemplate = false
             var invalidTarget = false
@@ -284,9 +285,15 @@ export default {
                     invalidTarget = true
                     this.$toasted.error('One or more presets have an invalid target. Please check the format and try again.')
                 }
+                if (!deadlineAfterDueDate && this.assignmentDetails.due_date &&
+                    Date.parse(node.deadline) > Date.parse(this.assignmentDetails.due_date)) {
+                    deadlineAfterDueDate = true
+                    this.$toasted.error('One or more presets have a deadline after the assignment due date. Please check the format and try again.')
+                }
             }
 
-            if (missingAssignmentName | missingPointMax | invalidDate | invalidTemplate | invalidTarget | targetsOutOfOrder) {
+            if (missingAssignmentName | missingPointMax | invalidDate | invalidTemplate | invalidTarget | targetsOutOfOrder |
+                deadlineAfterDueDate) {
                 return
             }
             this.saveRequestInFlight = true


### PR DESCRIPTION
## Description
Deadlines can now only be before the due date of an assignment. Previously this was not enforced which resulted in invalid deadlines. In case no due date is set, deadlines can be freely chosen.
