### PR TITLE
Enhancement: Added async loading for the student cards on the assignment page

### DIFF
--- a/src/vue/src/components/assignment/StudentLinkCard.vue
+++ b/src/vue/src/components/assignment/StudentLinkCard.vue
@@ -1,0 +1,46 @@
+<template>
+    <b-link tag="b-button" :to="{ name: 'Journal',
+                                  params: {
+                                      cID: cID,
+                                      aID: aID,
+                                      jID: jID
+                                  }, query: query
+                                }">
+
+        <student-card
+            :student="jStudent"
+            :stats="jStats">
+        </student-card>
+    </b-link>
+</template>
+
+<script>
+import studentCard from '@/components/assignment/StudentCard.vue'
+
+export default {
+    name: 'StudentLinkCard',
+    props: {
+        cID: {
+            required: true
+        },
+        aID: {
+            required: true
+        },
+        jID: {
+            required: true
+        },
+        query: {
+            required: true
+        },
+        jStudent: {
+            required: true
+        },
+        jStats: {
+            required: true
+        }
+    },
+    components: {
+        'student-card': studentCard
+    }
+}
+</script>

--- a/src/vue/src/views/Assignment.vue
+++ b/src/vue/src/views/Assignment.vue
@@ -35,20 +35,18 @@
             </b-button>
         </b-card>
 
+        <!--
+            The student-cards will be loaded asynchronous once the
+            heavy querie that loads in all the student data is finished.
+        -->
         <div v-if="filteredJournals" v-for="journal in filteredJournals" :key="journal.student.id" slot="main-content-column">
-            <b-link tag="b-button" :to="{ name: 'Journal',
-                                          params: {
-                                              cID: cID,
-                                              aID: aID,
-                                              jID: journal.id
-                                          }, query: query
-                                        }">
-
-                <student-card
-                    :student="journal.student"
-                    :stats="journal.stats">
-                </student-card>
-            </b-link>
+            <student-Linkcard
+                :cID="cID"
+                :aID="aID"
+                :jID="journal.id"
+                :query="query"
+                :jStudent="journal.student"
+                :jStats="journal.stats"/>
         </div>
         <main-card v-if="assignmentJournals.length === 0" slot="main-content-column" class="no-hover" :line1="'No participants with a journal'"/>
         <main-card v-else-if="filteredJournals.length === 0" slot="main-content-column" class="no-hover" :line1="'No journals found'"/>
@@ -64,7 +62,6 @@
 
 <script>
 import contentColumns from '@/components/columns/ContentColumns.vue'
-import studentCard from '@/components/assignment/StudentCard.vue'
 import mainCard from '@/components/assets/MainCard.vue'
 import statisticsCard from '@/components/assignment/StatisticsCard.vue'
 import breadCrumb from '@/components/assets/BreadCrumb.vue'
@@ -99,7 +96,7 @@ export default {
     },
     components: {
         'content-columns': contentColumns,
-        'student-card': studentCard,
+        'student-Linkcard': () => import('@/components/assignment/StudentLinkCard.vue'),
         'statistics-card': statisticsCard,
         'bread-crumb': breadCrumb,
         store,


### PR DESCRIPTION
## Description
On the Assignment page a  query is ran to get all the information of the students of a specific assignment to render all the student cards. This query takes a long time, one of the reasons are already mentioned in issue: #375, but due to this the rest of the page won't be rendered until this query is finished.

## Summary of changes
This enhancement lets the page render the student cards asynchronous so that the rest of the page can be rendered until this query is finished and the student cards can also be rendered.