### PR TITLE
Use vue-flatpickr for datetime inputs

### DIFF
--- a/src/vue/package-lock.json
+++ b/src/vue/package-lock.json
@@ -5180,6 +5180,11 @@
         "write": "^0.2.1"
       }
     },
+    "flatpickr": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.2.tgz",
+      "integrity": "sha512-jDy4QYGpmiy7+Qk8QvKJ4spjDdxcx9cxMydmq1x427HkKWBw0qizLYeYM2F6tMcvvqGjU5VpJS55j4LnsaBblA=="
+    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -15198,6 +15203,14 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "vue-flatpickr-component": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vue-flatpickr-component/-/vue-flatpickr-component-8.0.0.tgz",
+      "integrity": "sha512-PQ8D2sa25a05J4EyCK/iZIUM85zp8Ahlg+7S8XknwFqYcuayeo3r9bqVppT36QEO07Cyne4XPnjIMGHIh0hZ7Q==",
+      "requires": {
+        "flatpickr": "^4.5.1"
       }
     },
     "vue-functional-data-merge": {

--- a/src/vue/package.json
+++ b/src/vue/package.json
@@ -20,6 +20,7 @@
     "vue": "^2.5.2",
     "vue-awesome": "^2.3.7",
     "vue-cli": "^2.9.6",
+    "vue-flatpickr-component": "^8.0.0",
     "vue-pdf": "^3.3.1",
     "vue-router": "^3.0.1",
     "vue-sortable": "^0.1.3",

--- a/src/vue/src/components/assignment/CreateAssignment.vue
+++ b/src/vue/src/components/assignment/CreateAssignment.vue
@@ -23,24 +23,21 @@
             <b-row>
                 <b-col xl="4">
                     <h2 class="field-heading">Unlock date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="form.unlockDate && form.unlockDate.replace(' ', 'T')"
-                    @input="form.unlockDate = $event && $event.replace('T', ' ')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="form.unlockDate"
+                    :config="flatPickrConfig"/>
                 </b-col>
                 <b-col xl="4">
                     <h2 class="field-heading">Due date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="form.dueDate && form.dueDate.replace(' ', 'T')"
-                    @input="form.dueDate = $event && $event.replace('T', ' ')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="form.dueDate"
+                    :config="flatPickrConfig"/>
                 </b-col>
                 <b-col xl="4">
                     <h2 class="field-heading">Lock date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="form.lockDate && form.lockDate.replace(' ', 'T')"
-                    @input="form.lockDate = $event && $event.replace('T', ' ')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="form.lockDate"
+                    :config="flatPickrConfig"/>
                 </b-col>
             </b-row>
             <b-button class="float-left change-button mt-2" type="reset">
@@ -58,6 +55,8 @@
 <script>
 import textEditor from '@/components/assets/TextEditor.vue'
 import icon from 'vue-awesome/components/Icon'
+import flatPickr from 'vue-flatpickr-component'
+import 'flatpickr/dist/flatpickr.css'
 
 import assignmentAPI from '@/api/assignment'
 
@@ -75,11 +74,16 @@ export default {
                 unlockDate: null,
                 dueDate: null,
                 lockDate: null
+            },
+            flatPickrConfig: {
+                enableTime: true,
+                time_24hr: true
             }
         }
     },
     components: {
         'text-editor': textEditor,
+        flatPickr,
         icon
     },
     methods: {

--- a/src/vue/src/components/format/FormatEditAssignmentDetailsCard.vue
+++ b/src/vue/src/components/format/FormatEditAssignmentDetailsCard.vue
@@ -23,27 +23,24 @@
             <b-row>
                 <b-col xl="4">
                     <h2 class="field-heading">Unlock date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="assignmentDetails.unlock_date && assignmentDetails.unlock_date.replace(' ', 'T')"
-                    @input="assignmentDetails.unlock_date = $event && $event.replace('T', ' ')"
-                    @change="$emit('changed')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="assignmentDetails.unlock_date"
+                    @on-change="$emit('changed')"
+                    :config="flatPickrConfig"/>
                 </b-col>
                 <b-col xl="4">
                     <h2 class="field-heading">Due date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="assignmentDetails.due_date && assignmentDetails.due_date.replace(' ', 'T')"
-                    @input="assignmentDetails.due_date = $event && $event.replace('T', ' ')"
-                    @change="$emit('changed')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="assignmentDetails.due_date"
+                    @on-change="$emit('changed')"
+                    :config="flatPickrConfig"/>
                 </b-col>
                 <b-col xl="4">
                     <h2 class="field-heading">Lock date</h2>
-                    <b-input class="multi-form theme-input"
-                    :value="assignmentDetails.lock_date && assignmentDetails.lock_date.replace(' ', 'T')"
-                    @input="assignmentDetails.lock_date = $event && $event.replace('T', ' ')"
-                    @change="$emit('changed')"
-                    type="datetime-local"/>
+                    <flat-pickr class="multi-form theme-input"
+                    v-model="assignmentDetails.lock_date"
+                    @on-change="$emit('changed')"
+                    :config="flatPickrConfig"/>
                 </b-col>
             </b-row>
         </b-form>
@@ -53,9 +50,19 @@
 <script>
 import textEditor from '@/components/assets/TextEditor.vue'
 import icon from 'vue-awesome/components/Icon'
+import flatPickr from 'vue-flatpickr-component'
+import 'flatpickr/dist/flatpickr.css'
 
 export default {
     name: 'FormatEditAssignmentDetailsCard',
+    data () {
+        return {
+            flatPickrConfig: {
+                enableTime: true,
+                time_24hr: true
+            }
+        }
+    },
     props: {
         assignmentDetails: {
             required: true
@@ -63,6 +70,7 @@ export default {
     },
     components: {
         'text-editor': textEditor,
+        flatPickr,
         icon
     }
 }


### PR DESCRIPTION
## Description
Use [vue-flatpickr](https://github.com/ankurk91/vue-flatpickr-component) instead of browser datetime-local input.

![image](https://user-images.githubusercontent.com/29678823/46250643-58681500-c43f-11e8-8331-555a14c9e8ab.png)


## Summary of changes
- Fixes #382
