### PR TITLE
Fixed removed student journal error

### DIFF
--- a/src/django/VLE/serializers.py
+++ b/src/django/VLE/serializers.py
@@ -139,7 +139,8 @@ class AssignmentSerializer(serializers.ModelSerializer):
             journals = Journal.objects.filter(assignment=assignment)
 
             if 'course' in self.context:
-                journals = [journ for journ in journals if Participation.objects.filter(user=journ.user, course=self.context['course']).count() > 0]
+                journals = [journ for journ in journals
+                            if Participation.objects.filter(user=journ.user, course=self.context['course']).count() > 0]
 
             return JournalSerializer(
                 journals,


### PR DESCRIPTION
## Description
The error occurred due the fact that on an assignment in a course it would load all the journals, without looking if the journal corresponded to the correct course. We expanded the get journals function so that when a course is given in the context it will only respond with the journals that are in the course, otherwise it will still respond with all the journals for a specific assignment.

## Summary of changes
- Fixes #390 
