### PR TITLE
lti generator, BUGFIX token has no .encode, lti uses correct secret.

### DIFF
--- a/lti/lti_generator.py
+++ b/lti/lti_generator.py
@@ -1,6 +1,11 @@
 import os
-print('key')
+
+# Generates a new key and secret couple for the lti Oauth communication te key
+# and secrect are generated according to the guidelines given in
+# https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/
+
+print('LTI_KEY:')
 print(os.urandom(16).hex())
 print()
-print('secret')
+print('LTI_SECRET:')
 print(os.urandom(32).hex())

--- a/lti/lti_generator.py
+++ b/lti/lti_generator.py
@@ -1,0 +1,6 @@
+import os
+print('key')
+print(os.urandom(16).hex())
+print()
+print('secret')
+print(os.urandom(32).hex())

--- a/lti/lti_generator.py
+++ b/lti/lti_generator.py
@@ -1,11 +1,11 @@
-import os
+import secrets
 
 # Generates a new key and secret couple for the lti Oauth communication te key
 # and secrect are generated according to the guidelines given in
 # https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/
 
 print('LTI_KEY:')
-print(os.urandom(16).hex())
+print(secrets.token_hex(16))
 print()
 print('LTI_SECRET:')
-print(os.urandom(32).hex())
+print(secrets.token_hex(32))

--- a/src/django/VLE/views/lti.py
+++ b/src/django/VLE/views/lti.py
@@ -145,8 +145,8 @@ def lti_launch(request):
 
         refresh = TokenObtainPairSerializer.get_token(user)
         query = QueryDict.fromkeys(['lti_params'], lti_params, mutable=True)
-        query['jwt_access'] = refresh.access_token
-        query['jwt_refresh'] = refresh
+        query['jwt_access'] = str(refresh.access_token)
+        query['jwt_refresh'] = str(refresh)
         query['state'] = LOGGED_IN
         return redirect(lti.create_lti_query_link(query))
 

--- a/src/django/VLE/views/lti.py
+++ b/src/django/VLE/views/lti.py
@@ -36,7 +36,7 @@ def get_lti_params_from_jwt(request, jwt_params):
 
     user = request.user
     try:
-        lti_params = jwt.decode(jwt_params, settings.LTI_SECRET, algorithms=['HS256'])
+        lti_params = jwt.decode(jwt_params, settings.SECRET_KEY, algorithms=['HS256'])
     except jwt.exceptions.ExpiredSignatureError:
         return response.forbidden(
             description='The canvas link has expired, 15 minutes have passed. Please retry from canvas.')
@@ -121,7 +121,7 @@ def lti_launch(request):
         user = lti.check_user_lti(params, roles)
 
         params['exp'] = datetime.datetime.utcnow() + datetime.timedelta(minutes=15)
-        lti_params = jwt.encode(params, secret, algorithm='HS256').decode('utf-8')
+        lti_params = jwt.encode(params, settings.SECRET_KEY, algorithm='HS256').decode('utf-8')
 
         if user is None:
             q_names = ['state', 'lti_params']

--- a/src/django/VLE/views/user.py
+++ b/src/django/VLE/views/user.py
@@ -108,7 +108,7 @@ class UserView(viewsets.ViewSet):
         """
         if 'jwt_params' in request.data and request.data['jwt_params'] != '':
             try:
-                lti_params = jwt.decode(request.data['jwt_params'], settings.LTI_SECRET, algorithms=['HS256'])
+                lti_params = jwt.decode(request.data['jwt_params'], settings.SECRET_KEY, algorithms=['HS256'])
             except jwt.exceptions.ExpiredSignatureError:
                 return response.forbidden(
                     description='Your session has expired. Please go back to your learning environment and try again.')
@@ -190,7 +190,7 @@ class UserView(viewsets.ViewSet):
 
         if 'jwt_params' in request.data and request.data['jwt_params'] != '':
             try:
-                lti_params = jwt.decode(request.data['jwt_params'], settings.LTI_SECRET, algorithms=['HS256'])
+                lti_params = jwt.decode(request.data['jwt_params'], settings.SECRET_KEY, algorithms=['HS256'])
             except jwt.exceptions.ExpiredSignatureError:
                 return response.forbidden(
                     description='The canvas link has expired, 15 minutes have passed. Please retry from canvas.')


### PR DESCRIPTION
## Summary of changes
- Fixes token has no encode when entering to lti a second time.
- Fixes lti jwt encode uses our jwt secret
- .ADDED lti key secret couple generator
