### PR TITLE
Feature/insight stats filter on groups with bugfixes

### DIFF
--- a/src/django/VLE/views/participation.py
+++ b/src/django/VLE/views/participation.py
@@ -126,9 +126,11 @@ class ParticipationView(viewsets.ViewSet):
             request.user.check_permission('can_edit_course_roles', course)
             participation.role = Role.objects.get(name=role_name, course=course)
 
+        request.user.check_permission('can_edit_course_user_group', course)
         if group_name:
-            request.user.check_permission('can_edit_course_user_group', course)
             participation.group = Group.objects.get(name=group_name, course=course)
+        else:
+            participation.group = None
 
         participation.save()
         serializer = UserSerializer(participation.user, context={'course': course})

--- a/src/vue/src/views/Assignment.vue
+++ b/src/vue/src/views/Assignment.vue
@@ -56,9 +56,9 @@
 
         <div v-if="stats" slot="right-content-column">
             <h3>Insights</h3>
-            <statistics-card :subject="'Needs marking'" :num="stats.needs_marking"/>
+            <statistics-card :subject="'Needs marking'" :num="stats.needsMarking"/>
             <statistics-card :subject="'Unpublished grades'" :num="stats.unpublished"/>
-            <statistics-card :subject="'Average points'" :num="stats.average_points"/>
+            <statistics-card :subject="'Average points'" :num="stats.averagePoints"/>
         </div>
     </content-columns>
 </template>
@@ -124,7 +124,6 @@ export default {
             .then(assignment => {
                 this.loadingJournals = false
                 this.assignmentJournals = assignment.journals
-                this.stats = assignment.stats
             })
             .catch(error => {
                 this.$toasted.error(error.response.data.description)
@@ -203,6 +202,20 @@ export default {
         },
         toggleOrder () {
             this.order = !this.order
+        },
+        calcStats (filteredJournals) {
+            var needsMarking = 0
+            var unpublished = 0
+            var points = 0
+
+            for (var i = 0; i < filteredJournals.length; i++) {
+                needsMarking += filteredJournals[i]['stats']['submitted'] - filteredJournals[i]['stats']['graded']
+                unpublished += filteredJournals[i]['stats']['submitted'] - filteredJournals[i]['stats']['published']
+                points += filteredJournals[i]['stats']['acquired_points']
+            }
+            this.stats['needsMarking'] = needsMarking
+            this.stats['unpublished'] = unpublished - needsMarking
+            this.stats['averagePoints'] = points / filteredJournals.length
         }
     },
     computed: {
@@ -232,11 +245,7 @@ export default {
 
             function groupFilter (assignment) {
                 if (self.selectedFilterGroupOption) {
-                    if (!assignment.student.group) {
-                        return assignment.student.group === self.selectedFilterGroupOption
-                    } else {
-                        return assignment.student.group.includes(self.selectedFilterGroupOption)
-                    }
+                    return assignment.student.group === self.selectedFilterGroupOption
                 }
 
                 return true
@@ -252,6 +261,7 @@ export default {
             }
 
             this.updateQuery()
+            this.calcStats(store.state.filteredJournals.filter(groupFilter))
 
             return store.state.filteredJournals.filter(groupFilter).slice()
         }


### PR DESCRIPTION
## Description
Implemented Insight stats on filtered groups
Bugfix on calculating stats on all journals instead of an assignment
Bugfix changing student groups to none
Bugfix filter with matching substring

## Summary of changes
- Fixes #352 

![image](https://user-images.githubusercontent.com/15890415/47295905-19c61480-d611-11e8-8f62-57edcca3a9a7.png)
No filter

![image](https://user-images.githubusercontent.com/15890415/47295923-26e30380-d611-11e8-8beb-d468a861498e.png)
Filter on Test

![image](https://user-images.githubusercontent.com/15890415/47296017-5e51b000-d611-11e8-8c33-48777fd22936.png)
Filter on Test2