### PR TITLE
Only redirect to format editor upon creation of LTI assignment

### DIFF
--- a/src/django/VLE/views/lti.py
+++ b/src/django/VLE/views/lti.py
@@ -98,7 +98,7 @@ def get_lti_params_from_jwt(request, jwt_params):
 
         journal = lti.select_create_journal(lti_params, user, assignment)
         jID = journal.pk if journal is not None else None
-        state = FINISH_T if user.has_permission('can_grade', assignment) else FINISH_S
+        state = FINISH_T if user.has_permission('can_view_all_journals', assignment) else FINISH_S
     except KeyError as err:
         raise VLEMissingRequiredKey(err)
 

--- a/src/vue/src/views/LtiLaunch.vue
+++ b/src/vue/src/views/LtiLaunch.vue
@@ -214,15 +214,27 @@ export default {
                 })
                 break
             case this.states.finish_t:
-                /* Teacher has created or linked a new course and or assignment, we need to update the store. */
+                /* Teacher might have created or linked a new course and or assignment, we need to update the store. */
                 this.$store.dispatch('user/populateStore').then(_ => {
-                    this.$router.push({
-                        name: 'FormatEdit',
-                        params: {
-                            cID: this.page.cID,
-                            aID: this.page.aID
-                        }
-                    })
+                    if (this.tempStateToCheckIfWeCanAutoSetup === this.states.finish_t) {
+                        /* The assignment already existed. */
+                        this.$router.push({
+                            name: 'Assignment',
+                            params: {
+                                cID: this.page.cID,
+                                aID: this.page.aID
+                            }
+                        })
+                    } else {
+                        /* A new assignment has been created, yet to be configured. */
+                        this.$router.push({
+                            name: 'FormatEdit',
+                            params: {
+                                cID: this.page.cID,
+                                aID: this.page.aID
+                            }
+                        })
+                    }
                 }, error => {
                     this.$router.push({
                         name: 'ErrorPage',


### PR DESCRIPTION
## Description
Teachers will now only be redirected to the format editor in case they created a new assignment through LTI. In case the assignment already exists they will be redirected to the assignment page instead.

## Summary of changes
- Changed permission check for LTI state to can_view_all_journals instead of can_grade
- Updated LTI redirection