### PR TITLE
Fixed login redirection issue

### DIFF
--- a/src/vue/src/router/index.js
+++ b/src/vue/src/router/index.js
@@ -116,7 +116,10 @@ var router = new Router({
 
 router.beforeEach((to, from, next) => {
     const loggedIn = store.getters['user/loggedIn']
-    router.app.previousPage = from
+
+    if (from.name) {
+        router.app.previousPage = from
+    }
 
     if (loggedIn && routerConstraints.UNAVAILABLE_WHEN_LOGGED_IN.has(to.name)) {
         next({name: 'Home'})
@@ -124,6 +127,7 @@ router.beforeEach((to, from, next) => {
         store.dispatch('user/validateToken')
             .then(_ => { next() })
             .catch(_ => {
+                router.app.previousPage = to
                 next({name: 'Login'})
             })
     } else { next() }


### PR DESCRIPTION
## Description
Fixed an issue where the user would not be redirected to the page they originally intended to go to before being presented with the login prompt.

This was caused by the fact that the `previousPage` variable (which we redirect to after logging in) was overwritten to a page with name `null` by the router redirect to the login page itself. 

## Summary of changes
- Fixes #517 