### PR TITLE
Fixed an issue where users could not type their password when linking an account in Firefox

### DIFF
--- a/src/vue/src/components/lti/LtiCreateLinkUser.vue
+++ b/src/vue/src/components/lti/LtiCreateLinkUser.vue
@@ -37,7 +37,8 @@
             ref="linkUserRef"
             title="Link to existing eJournal account"
             size="lg"
-            hide-footer>
+            hide-footer
+            no-enforce-focus>
                 <login-form @handleAction="handleLinked"/>
         </b-modal>
     </b-row>


### PR DESCRIPTION
Firefox cannot handle password fields in modals.