### PR TITLE
Maxed rounding to two decimals only when necessary, NaN is always dis…

### DIFF
--- a/src/vue/src/components/assets/TodoSquare.vue
+++ b/src/vue/src/components/assets/TodoSquare.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="todo-square" :class="num ? 'num-nonzero' : 'num-zero'">
-        {{ num }}
+        {{ num ? Math.round(num * 100) / 100 : 0 }}
     </div>
 </template>
 


### PR DESCRIPTION
## Description
Maxed statistic rounding to two decimals only when necessary, NaN is always displayed as 0.

## Summary of changes
- Fixes #541 
