### PR TITLE
Fixed an issue where entries were hidden for students after the corresponding preset lock date expired

### DIFF
--- a/src/vue/src/components/journal/JournalStudent.vue
+++ b/src/vue/src/components/journal/JournalStudent.vue
@@ -93,7 +93,7 @@
                         :bonusPoints="journal.bonus_points"
                     />
                     <b-card
-                        v-else-if="nodes[currentNode].type == 'd' && currentNodeIsLocked"
+                        v-else-if="nodes[currentNode].type == 'd' && !nodes[currentNode].entry && currentNodeIsLocked"
                         :class="$root.getBorderClass($route.params.cID)"
                         class="no-hover"
                     >


### PR DESCRIPTION
Students were temporarily unable to view previously posted entries if the corresponding preset node had a lock date in the past. Instead, they would be presented with:

![image](https://user-images.githubusercontent.com/39912581/92304965-1462e080-ef83-11ea-8824-c9e8462e8dd1.png)


This issue has now been resolved.